### PR TITLE
Fix invalid PIP dependencies

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,4 @@
 requests
-yaml
-logging
+pyyaml
 tabulate
 


### PR DESCRIPTION
The logging module is part of the the python standard library.

The yaml module is provided by the pyyaml PIP package.